### PR TITLE
(HGI-4375) added log for null access or refresh token

### DIFF
--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -67,8 +67,11 @@ class ZoomClient(object):
                 'grant_type': 'refresh_token'
             })
 
-        self.__access_token = data['access_token']
-        self.__refresh_token = data['refresh_token']
+        try:
+            self.__access_token = data['access_token']
+            self.__refresh_token = data['refresh_token']
+        except:
+            LOGGER.error("Access token or Refresh token cannot be empty. Please check credentials and try again.")
 
         self.__expires_at = datetime.utcnow() + \
             timedelta(seconds=data['expires_in'] - 10) # pad by 10 seconds for clock drift

--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -71,7 +71,7 @@ class ZoomClient(object):
             self.__access_token = data['access_token']
             self.__refresh_token = data['refresh_token']
         except:
-            LOGGER.error("Access token or Refresh token cannot be empty. Please check credentials and try again.")
+            LOGGER.error("fFailed to refresh OAuth tokens, response from Zoom API = [{data}]")
 
         self.__expires_at = datetime.utcnow() + \
             timedelta(seconds=data['expires_in'] - 10) # pad by 10 seconds for clock drift

--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -71,7 +71,7 @@ class ZoomClient(object):
             self.__access_token = data['access_token']
             self.__refresh_token = data['refresh_token']
         except:
-            LOGGER.error("fFailed to refresh OAuth tokens, response from Zoom API = [{data}]")
+            LOGGER.error(f"Failed to refresh OAuth tokens, response from Zoom API = [{data}]")
 
         self.__expires_at = datetime.utcnow() + \
             timedelta(seconds=data['expires_in'] - 10) # pad by 10 seconds for clock drift


### PR DESCRIPTION
# Description of change
Added log for when access token or refresh token returns null to clarify error in hotglue logs.
